### PR TITLE
Improved task names; added restart task

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Then, running cap -vT | grep resque should give you...
 
 ```
 ➔ cap -vT | grep resque
-cap resque:start_workers     # Start Resque workers
-cap resque:stop_workers      # Quit running Resque workers
+cap resque:start     # Start Resque workers
+cap resque:stop      # Quit running Resque workers
+cap resque:restart   # Restart running Resque workers
 ```
+
+### Restart on deployer
+
+To restart you workers automatically when `cap deploy:restart` is executed
+add the following line to your `deploy.rb`:
+
+```
+after "deploy:restart", "resque:restart"
+```
+

--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -25,7 +25,7 @@ module CapistranoResque
 
         namespace :resque do
           desc "Start Resque workers"
-          task :start_workers do
+          task :start do
             puts "Starting #{num_of_queues} worker(s) with QUEUE: #{queue_name}"
             num_of_queues.times do |i|
               pid = "./tmp/pids/resque_worker_#{i}.pid"
@@ -36,7 +36,7 @@ bundle exec rake environment resque:work"
           end
 
           desc "Quit running Resque workers"
-          task :stop_workers do
+          task :stop do
             current_pids.each do |pid|
               if remote_file_exists?(pid)
                 if remote_process_exists?(pid)
@@ -50,6 +50,12 @@ bundle exec rake environment resque:work"
                 logger.important("No PIDs found. Check if Resque is running.", "Resque")
               end
             end
+          end
+
+          desc "Restart running Resque workers"
+          task :restart do
+            stop
+            start
           end
         end
       end


### PR DESCRIPTION
This commit uses the start/stop/restart convention within the
resque namespace. Documentation has been updated to reflect this.

Documentation now also shows how to automatically restart workers in
the normal deploy flow of your application.
