### PR TITLE
current_pids does not work on Ubuntu 12.04LTS

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -20,7 +20,7 @@ module CapistranoResque
         end
 
         def current_pids
-          capture("ls #{current_path}/tmp/pids/resque_work*.pid").strip.split("\r\n")
+          capture("ls #{current_path}/tmp/pids/resque_work*.pid").strip.split(/\r{0,1}\n/)
         end
 
         namespace :resque do


### PR DESCRIPTION
On https://github.com/sshingler/capistrano-resque/blob/master/lib/capistrano-resque/capistrano_integration.rb#L23 you split the output of `ls` with `\r\n`. I've noticed that, when running with multiple workers, this does not work well with my current Ubuntu 12.04LTS install. File entries here are separated by `\n`, not `\r\n`.

I'm not sure if this is a bug, or if `\r\n` is needed on other platforms.

I think using a regex here would be appropriate to facilitate both scenario's.
