### PR TITLE
Support for different queue/worker combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,25 @@ require "capistrano-resque"
 ### In your deploy.rb:
 
 ```
-set :queue_name, "my_queue_name"
-set :num_of_queues, 2
+set :workers, { "my_queue_name" => 2 }
 ```
 
-Then, running cap -vT | grep resque should give you...
+You can also specify multiple queues and the number of workers
+for each queue:
+
+```
+set :workers, { "archive" => 1, "mailing" => 3, "search_index, cache_warming" => 1 }
+```
+
+The above will start five workers in total:
+
+ * one listening on the `archive` queue
+ * one listening on the `search_index, cache_warming` queue
+ * three listening on the `mailing` queue
+
+### The tasks
+
+Running cap -vT | grep resque should give you...
 
 ```
 ➔ cap -vT | grep resque

--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -6,8 +6,7 @@ module CapistranoResque
     def self.load_into(capistrano_config)
       capistrano_config.load do
 
-        _cset(:num_of_queues, 1)
-        _cset(:queue_name, "*")
+        _cset(:workers, {"*" => 1})
         _cset(:app_env, (fetch(:rails_env) rescue "production"))
         _cset(:verbosity, 1)
 
@@ -26,12 +25,17 @@ module CapistranoResque
         namespace :resque do
           desc "Start Resque workers"
           task :start_workers do
-            puts "Starting #{num_of_queues} worker(s) with QUEUE: #{queue_name}"
-            num_of_queues.times do |i|
-              pid = "./tmp/pids/resque_worker_#{i}.pid"
-              run "cd #{current_path} && RAILS_ENV=#{app_env} QUEUE=#{queue_name} \
-PIDFILE=#{pid} BACKGROUND=yes LOGFILE=./log/resque-worker#{i}.log VVERBOSE=#{verbosity}  \
-bundle exec rake environment resque:work"
+            worker_id = 1
+
+            workers.each_pair do |queue, number_of_workers|
+              puts "Starting #{number_of_workers} worker(s) with QUEUE: #{queue}"
+              number_of_workers.times do
+                pid = "./tmp/pids/resque_worker_#{worker_id}.pid"
+                run "cd #{current_path} && RAILS_ENV=#{app_env} QUEUE=\"#{queue}\" \
+  PIDFILE=#{pid} BACKGROUND=yes LOGFILE=./log/resque-worker#{worker_id}.log VVERBOSE=#{verbosity}  \
+  bundle exec rake environment resque:work"
+                worker_id += 1
+              end
             end
           end
 


### PR DESCRIPTION
At this time you can configure the queues you want to process and the number of workers. It might be useful to specify different queues and worker numbers.

A configuration could be:

```
set :resque, { "queue1, other_queue" => 2, "different_queue" => 4 }
```

This would start 2 workers working on queue1, other_queue and 4 workers working on different_queue.

Would this be beneficial to this gem/plugin?
