### PR TITLE
Use `kill -9` for resque:stop

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -57,7 +57,7 @@ module CapistranoResque
               if remote_file_exists?(pid)
                 if remote_process_exists?(pid)
                   logger.important("Stopping...", "Resque Worker: #{pid}")
-                  run "#{try_sudo} kill `cat #{pid}`"
+                  run "#{try_sudo} kill -9 `cat #{pid}`"
                 else
                   run "rm #{pid}"
                   logger.important("Resque Worker #{pid} is not running.", "Resque")


### PR DESCRIPTION
Should we be using `kill -9` or `kill -s QUIT` to stop the old resque processes?
