### PR TITLE
Set correct RAILS_ENV value if capistrano using multistage

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -7,7 +7,6 @@ module CapistranoResque
       capistrano_config.load do
 
         _cset(:workers, {"*" => 1})
-        _cset(:app_env, (fetch(:rails_env) rescue "production"))
 
         def remote_file_exists?(full_path)
           "true" ==  capture("if [ -e #{full_path} ]; then echo 'true'; fi").strip
@@ -38,6 +37,7 @@ module CapistranoResque
           desc "Start Resque workers"
           task :start, :roles => :resque_worker do
             worker_id = 1
+            app_env = fetch(:rails_env, "production")
             workers.each_pair do |queue, number_of_workers|
               puts "Starting #{number_of_workers} worker(s) with QUEUE: #{queue}"
               number_of_workers.times do


### PR DESCRIPTION
Hi,

If Capistrano use multistage extnsion you gem set RAILS_ENV to 'production' always. Looks like in multistage environment when you set :app_env variable, the :rails_env variable is undefined yet and it cause exception and you set 'production' string by default).

Thanks

About multistage: 
http://weblog.jamisbuck.org/2007/7/23/capistrano-multistage
http://paulschreiber.com/blog/2011/02/12/howto-setup-multistage-deployment-with-capistrano/  (I use similar solution i.e. configure rails_env variable in deploy/(staging|production).rb files)
