### PR TITLE
Diff workers foreach server

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -75,7 +75,7 @@ PIDFILE=./tmp/pids/scheduler.pid BACKGROUND=yes bundle exec rake resque:schedule
             task :stop, :roles => :resque_scheduler do
               pid = "#{current_path}/tmp/pids/scheduler.pid"
               command = "if [ -e #{pid} ]; then \
-                #{try_sudo} kill $(cat #{pid}) ; rm #{pid} ; \
+                #{try_sudo} kill $(cat #{pid}) ; rm #{pid} \
                 ;fi"
               run(command)
               


### PR DESCRIPTION
from https://github.com/sshingler/capistrano-resque/issues/14

this allow you have multiple workers for different roles.
Example:
set :workers, { :api => { 'converter' => 1, 'purchase_converter' => 1 }, 
                :stats => { 'photo_recovery' => 1, 'store store_recovery' => 2 } }

Or you still can use the old method. having workers running in all :resque_worker servers
