### PR TITLE
The "&" at the end of the resque/resque-scheduler commands are redundant

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -42,7 +42,7 @@ module CapistranoResque
                 number_of_workers.times do
                   pid = "./tmp/pids/resque_work_#{worker_id}.pid"
                   run("cd #{current_path} && RAILS_ENV=#{rails_env} QUEUE=\"#{queue}\" \
-                   PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 #{fetch(:bundle_cmd, "bundle")} exec rake environment resque:work >> #{shared_path}/log/resque.log 2>&1 &", 
+                   PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 #{fetch(:bundle_cmd, "bundle")} exec rake environment resque:work >> #{shared_path}/log/resque.log 2>&1", 
                       :roles => role)
                   worker_id += 1
                 end


### PR DESCRIPTION
Because there is allready a `BACKGROUND=yes` in the tasks, the `&` at the end to backgrond the commaned should not be needed.    The deployment only worked for us after removing them.
