### PR TITLE
Start multiple workers in threads, to get O(1) start time vs O(n)

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -69,11 +69,13 @@ module CapistranoResque
               worker_id = 1
               workers.each_pair do |queue, number_of_workers|
                 puts "Starting #{number_of_workers} worker(s) with QUEUE: #{queue}"
+                threads = []
                 number_of_workers.times do
                   pid = "./tmp/pids/resque_work_#{worker_id}.pid"
-                  run(start_command(queue, pid), :roles => role)
+                  threads << Thread.new { run(start_command(queue, pid), :roles => role) }
                   worker_id += 1
                 end
+                threads.each(&:join)
               end
             end
           end


### PR DESCRIPTION
- Always takes the same time as 1 worker does to start
- Blocks on all workers starting successfully, so if you have a faulty deploy it will fail verbosely

(Related commit: https://github.com/sshingler/capistrano-resque/commit/8986054898d53947834babc25a299ba8fdc17950)
