### PR TITLE
Consistent verbosity for resque and resque scheduler tasks

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -47,7 +47,7 @@ module CapistranoResque
 
         def start_scheduler(pid)
           "cd #{current_path} && RAILS_ENV=#{rails_env} \
-           PIDFILE=#{pid} BACKGROUND=yes \
+           PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 \
            #{fetch(:bundle_cmd, "bundle")} exec rake resque:scheduler"
         end
 


### PR DESCRIPTION
Seems better to have `VERBOSE=1` for _both_ tasks.
