### PR TITLE
Use thread local variables when it may be changed from parent thread

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -72,7 +72,7 @@ module CapistranoResque
                 threads = []
                 number_of_workers.times do
                   pid = "./tmp/pids/resque_work_#{worker_id}.pid"
-                  threads << Thread.new { run(start_command(queue, pid), :roles => role) }
+                  threads << Thread.new(pid) { |pid| run(start_command(queue, pid), :roles => role) }
                   worker_id += 1
                 end
                 threads.each(&:join)


### PR DESCRIPTION
Sometimes pid files are only created resque_woker_#{last_worker_number}.pid, because variable(pid file path) used in child threads is changed in parent threads during starting these childs threads.

So I change to use thread local variables.
## Sample

```
$ cat /tmp/sample_has_problem.rb
threads = []
for i in 1..5
  foo = "foo#{i}"
  threads << Thread.new { puts foo }
end
threads.each(&:join)
$ ruby /tmp/sample_has_problem.rb
foo5
foo5
foo5foo5
foo5

$ cat /tmp/sample.rb
threads = []
for i in 1..5
  foo= "foo#{i}"
  threads << Thread.new(foo) { |foo| puts foo }
end
threads.each(&:join)
$ cat /tmp/sample.rb
foo2foo4foo1foo3foo5
```
