### PR TITLE
re added environment load task for resque start

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -35,7 +35,7 @@ module CapistranoResque
         def start_command(queue, pid)
           "cd #{current_path} && RAILS_ENV=#{rails_env} QUEUE=\"#{queue}\" \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{interval} \
-           #{fetch(:bundle_cmd, "bundle")} exec rake resque:work"
+           #{fetch(:bundle_cmd, "bundle")} exec rake environment resque:work"
         end
 
         def stop_command


### PR DESCRIPTION
environment load task for resque start is not redundant at least for me on rails 3.0.16 and ruby 1.8.7 
