### PR TITLE
Fix resque_scheduler startup for master branch of resque_scheduler

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -48,7 +48,7 @@ module CapistranoResque
 
         def start_scheduler(pid)
           "cd #{current_path} && RAILS_ENV=#{rails_env} \
-           PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 \
+           PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 \
            #{fetch(:bundle_cmd, "bundle")} exec rake resque:scheduler"
         end
 


### PR DESCRIPTION
Current master branch of resque_scheduler changed behavior of invoking  Process.daemon ( https://github.com/bvandenbos/resque-scheduler/commit/c45d9977bc1448d34fa09c94b4516e950bac0d70 )

If you don't use MUTE env var, capistrano will hang forever on resque_scheduler startup.
