### PR TITLE
Kill the resque process only if it is exists.

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -40,10 +40,10 @@ module CapistranoResque
 
         def stop_command
           "if [ -e #{current_path}/tmp/pids/resque_work_1.pid ]; then \
-           for f in `ls #{current_path}/tmp/pids/resque_work*.pid`; \
-             do #{try_sudo} kill -s #{resque_kill_signal} `cat $f` \
-             && rm $f ;done \
-           ;fi"
+            for f in `ls #{current_path}/tmp/pids/resque_work*.pid`; \
+              do ps -ef | grep `cat $f` | grep -v grep && #{try_sudo} kill -s #{resque_kill_signal} `cat $f`; \
+              rm $f ;done \
+          ;fi"
         end
 
         def start_scheduler(pid)


### PR DESCRIPTION
If the process is not existing anymore for some reason, stop command failed the deploy.

With this fix we make sure that process exists and kills it in that case, otherwise just remove the PID-file
