### PR TITLE
rescue in resque:stop task in order to allow for task chain execution to...

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,16 @@
+# unreleased
+# set variable raise_on_resque_stop to true if you want the resque:stop task to break the task chain execution,
+# leave as default or set explicitly to false in order to allow task chain execution to continue
+# e.g.
+# * executing `resque:stop'
+# * executing "if [ -e /whatever/current/tmp/pids/resque_work_1.pid ]; then for f in `ls /whatever/current/tmp/pids/resque_work*.pid`; do kill -s QUIT `cat $f` && rm $f ;done;fi"
+# servers: ["foo.com"]
+# [foo.com] executing command
+# *** [err :: foo.com] sh: line 0: kill: (1234) - No such process
+# command finished in 1234ms
+# failed: "sh -c 'if [ -e /whatever/current/tmp/pids/resque_work_1.pid ]; then for f in `ls /whatever/current/tmp/pids/resque_work*.pid`; do kill -s QUIT `cat $f` && rm $f ;done;fi'" on foo.com
+
+
 # 0.1.0
 Interval is configurable
 Fix issue where pids weren't created correctly

--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -89,7 +89,11 @@ module CapistranoResque
           # CONT - Start to process new jobs again after a USR2 (resume)
           desc "Quit running Resque workers"
           task :stop, :roles => lambda { workers_roles() }, :on_no_matching_servers => :continue do
-            run(stop_command)
+            begin
+              run(stop_command)
+            rescue Capistrano::CommandError => e
+              raise e if fetch(:raise_on_resque_stop_error, false)
+            end
           end
 
           desc "Restart running Resque workers"


### PR DESCRIPTION
If the pid file contains a defunct pid, the kill command exits with a failure code, and the task resque:stop fails.  If there is a chain of tasks, they all stop.  I think that this error should be non-fatal, so this is my attempt to allow for some continuation.  I'm not sure of maybe stop_command method might need a to change the && to something else, and ensure that rm -f $f runs anyway.
Thanks for making this gem 
