### PR TITLE
Don't fail the deploy when Resque is dead - just move on

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -41,9 +41,16 @@ module CapistranoResque
         def stop_command
           "if [ -e #{current_path}/tmp/pids/resque_work_1.pid ]; then \
            for f in `ls #{current_path}/tmp/pids/resque_work*.pid`; \
-             do #{try_sudo} kill -s #{resque_kill_signal} `cat $f` \
-             && rm $f ;done \
-           ;fi"
+              do \
+                if kill -0 `cat $f`> /dev/null 2>&1; then \
+                  #{try_sudo} kill -s #{resque_kill_signal} `cat $f` \
+                  && rm $f \
+                ;else \
+                  echo 'Resque was not running, cleaning up stale PID file' \
+                  && rm $f \
+                ;fi \
+              ;done \
+            ;fi"
         end
 
         def start_scheduler(pid)


### PR DESCRIPTION
In addition to checking whether and pidfiles exist at all, this change also checks whether each PID in the pid files found exists before attempting to kill it. Without this change, a pidfile referring to a stale process will cause the entire deploy to fail, because the kill command will fail.

With this change, we check using `kill -0` first to see if the process is alive. If not, we just echo a message and remove the pidfile anyway.

This is modelled after the way sidekiq's capistrano integration handles a similar situation here:
https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/capistrano.rb#L28
