### PR TITLE
Fixes Activerecord disconnection

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -67,7 +67,7 @@ module CapistranoResque
           desc "Start Resque workers"
           task :start, :roles => lambda { workers_roles() }, :on_no_matching_servers => :continue do
 
-            Resque.before_fork = Proc.new { ActiveRecord::Base.establish_connection }
+            Resque.before_fork = Proc.new { ActiveRecord::Base.establish_connection } if defined?(PG)
 
             for_each_workers do |role, workers|
               worker_id = 1


### PR DESCRIPTION
This happens when the Resque worker isn't re-initializing database connections after forking.
