### PR TITLE
Replace QUEUE=\"#{queue}\" with QUEUE='#{queue}' to avoid generating the...

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -33,7 +33,7 @@ module CapistranoResque
         end
 
         def start_command(queue, pid)
-          "cd #{current_path} && RAILS_ENV=#{rails_env} QUEUE=\"#{queue}\" \
+          "cd #{current_path} && RAILS_ENV=#{rails_env} QUEUE='#{queue}' \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{interval} \
            #{fetch(:bundle_cmd, "bundle")} exec rake resque:work"
         end


### PR DESCRIPTION
Replace QUEUE=\"#{queue}\" with QUEUE='#{queue}' to avoid generating the wrong queue name.

For example:

I do

```
set :workers, { "mailer" => 1 }
```

it will generate command like

```
executing "cd /home/apps/dappei/current && RAILS_ENV=staging QUEUE=\"mailer\"            PIDFILE=./tmp/pids/resque_work_1.pid BACKGROUND=yes VERBOSE=1 INTERVAL=5            bundle exec rake resque:work"
```

the QUEUE name will be "mailer", not mailer.
