### PR TITLE
environment call on resque:work missing

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -35,7 +35,7 @@ module CapistranoResque
         def start_command(queue, pid)
           "cd #{current_path} && RAILS_ENV=#{rails_env} QUEUE=\"#{queue}\" \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{interval} \
-           #{fetch(:bundle_cmd, "bundle")} exec rake resque:work"
+           #{fetch(:bundle_cmd, "bundle")} exec rake environment resque:work"
         end
 
         def stop_command


### PR DESCRIPTION
Concerning such bugs surging from projects using devise and resque calling resque:work rake task:

https://gist.github.com/snatchev/1316470

It was implemented a solution consisting of calling environment before resque:work, So that stuff could be eager-loaded (don't know what it does more). 

This solution was missing from the capistrano task of this gem. It is now in. 
