### PR TITLE
Add ability to set rails_env.

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -9,6 +9,7 @@ module CapistranoResque
         _cset(:workers, {"*" => 1})
         _cset(:resque_kill_signal, "QUIT")
         _cset(:interval, "5")
+        _cset(:capistrano_resque_rails_env)  { fetch :rails_env, "production" }
 
         def workers_roles
           return workers.keys if workers.first[1].is_a? Hash
@@ -33,7 +34,7 @@ module CapistranoResque
         end
 
         def start_command(queue, pid)
-          "cd #{current_path} && RAILS_ENV=#{rails_env} QUEUE=\"#{queue}\" \
+          "cd #{current_path} && RAILS_ENV=#{capistrano_resque_rails_env} QUEUE=\"#{queue}\" \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{interval} \
            #{fetch(:bundle_cmd, "bundle")} exec rake resque:work"
         end
@@ -47,7 +48,7 @@ module CapistranoResque
         end
 
         def start_scheduler(pid)
-          "cd #{current_path} && RAILS_ENV=#{rails_env} \
+          "cd #{current_path} && RAILS_ENV=#{capistrano_resque_rails_env} \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 \
            #{fetch(:bundle_cmd, "bundle")} exec rake resque:scheduler"
         end


### PR DESCRIPTION
Fall back on rails_env followed by "production" if capistrano_resque_rails_env is not set.

Inspiration came from a deploy.rb that sets its rails_env to an environment different than what is needed when running resque workers. I didn't like the following solution:

```
after "deploy:restart", "restart_resque"

desc "Restart Resque using capistrano-resque."
task "restart_resque" do
    set :rails_env, "environment needed for resque"
    resque.restart
    set :rails_env, "previous environment"
end
```

If an alternative, simpler solution exists please let me know and I'll close the pull request.

Solution adapted from https://github.com/javan/whenever/blob/master/lib/whenever/capistrano/recipes.rb
