### PR TITLE
Added version to the capistrano dependency.

### DIFF
--- a/capistrano-resque.gemspec
+++ b/capistrano-resque.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{|f| File.basename(f)}
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "capistrano"
+  gem.add_runtime_dependency "capistrano", ["< 3.0.0"]
   gem.add_runtime_dependency "resque"
   gem.add_runtime_dependency "resque-scheduler"
 end


### PR DESCRIPTION
At this point, `capistrano-resque` 0.1.0 is not compatible with `capistrano` 3.0.0. 

This should fix issue #60. 
