### PR TITLE
Send worker-start output to a log file. Works with resque 1.25.1

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -35,7 +35,7 @@ module CapistranoResque
         def start_command(queue, pid)
           "cd #{current_path} && RAILS_ENV=#{rails_env} QUEUE=\"#{queue}\" \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{interval} \
-           #{fetch(:bundle_cmd, "bundle")} exec rake resque:work"
+           #{fetch(:bundle_cmd, "bundle")} exec rake resque:work >> #{current_path}/log/resque.log"
         end
 
         def stop_command


### PR DESCRIPTION
With Resque 1.25.1, It appears they're sending the worker output to stout even with BACKGROUND=yes.

This fix sends that straight to ./log/resque.log and allows Capistrano to finish it's task. 
