### PR TITLE
Use resque_kill_signal setting when killing scheduler.

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -54,7 +54,7 @@ module CapistranoResque
 
         def stop_scheduler(pid)
           "if [ -e #{pid} ]; then \
-            #{try_sudo} kill $(cat #{pid}) ; rm #{pid} \
+            #{try_sudo} kill -s #{resque_kill_signal} $(cat #{pid}) ; rm #{pid} \
            ;fi"
         end
 


### PR DESCRIPTION
Work around for the following resque-scheduler issue.

https://github.com/resque/resque-scheduler/issues/205
