### PR TITLE
add resque:scheduler:status task

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -49,6 +49,12 @@ module CapistranoResque
            ;fi"
         end
 
+        def status_scheduler
+          "if [ -e #{current_path}/tmp/pids/scheduler.pid ]; then \
+             ps -p $(cat #{current_path}/tmp/pids/scheduler.pid) | sed -n 2p \
+           ;fi"
+        end
+
         def start_scheduler(pid)
           "cd #{current_path} && RAILS_ENV=#{rails_env} \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 \
@@ -102,6 +108,11 @@ module CapistranoResque
           end
 
           namespace :scheduler do
+            desc "See current scheduler status"
+            task :status, :roles => :resque_scheduler do
+              run(status_scheduler)
+            end
+
             desc "Starts resque scheduler with default configs"
             task :start, :roles => :resque_scheduler do
               pid = "#{current_path}/tmp/pids/scheduler.pid"

--- a/lib/capistrano-resque/tasks/capistrano-resque.rake
+++ b/lib/capistrano-resque/tasks/capistrano-resque.rake
@@ -89,6 +89,16 @@ namespace :resque do
   end
 
   namespace :scheduler do
+    desc "See current scheduler status"
+    task :status do
+      on roles :resque_scheduler do
+        pid = "#{current_path}/tmp/pids/scheduler.pid"
+        if test "[ -e #{pid} ]"
+          info capture(:ps, "-f -p $(cat #{pid}) | sed -n 2p")
+        end
+      end
+    end
+
     desc "Starts resque scheduler with default configs"
     task :start do
       on roles :resque_scheduler do


### PR DESCRIPTION
Adding a resque:scheduler:status task to mirror the resque:status task for worker threads.

Allows us to check to see if the scheduler is up and running.
