### PR TITLE
rake resque:start hangs if anything writes to STDOUT

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -38,7 +38,7 @@ module CapistranoResque
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{interval} \
            #{fetch(:bundle_cmd, "bundle")} exec rake \
            #{"environment" if fetch(:resque_environment_task)} \
-           resque:work"
+           resque:work > /dev/null"
         end
 
         def stop_command
@@ -58,7 +58,7 @@ module CapistranoResque
         def start_scheduler(pid)
           "cd #{current_path} && RAILS_ENV=#{rails_env} \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 \
-           #{fetch(:bundle_cmd, "bundle")} exec rake resque:scheduler"
+           #{fetch(:bundle_cmd, "bundle")} exec rake resque:scheduler > /dev/null"
         end
 
         def stop_scheduler(pid)

--- a/lib/capistrano-resque/tasks/capistrano-resque.rake
+++ b/lib/capistrano-resque/tasks/capistrano-resque.rake
@@ -47,7 +47,7 @@ namespace :resque do
           number_of_workers.times do
             pid = "./tmp/pids/resque_work_#{worker_id}.pid"
             within current_path do
-              execute :rake, %{RAILS_ENV=#{fetch(:rails_env)} QUEUE="#{queue}" PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{fetch(:interval)} #{"environment" if fetch(:resque_environment_task)} resque:work}
+              execute :rake, %{RAILS_ENV=#{fetch(:rails_env)} QUEUE="#{queue}" PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{fetch(:interval)} #{"environment" if fetch(:resque_environment_task)} resque:work > /dev/null}
             end
             worker_id += 1
           end
@@ -98,7 +98,7 @@ namespace :resque do
       on roles :resque_scheduler do
         pid = "#{current_path}/tmp/pids/scheduler.pid"
         within current_path do
-          execute :rake, %{RAILS_ENV=#{fetch(:rails_env)} PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 resque:scheduler}
+          execute :rake, %{RAILS_ENV=#{fetch(:rails_env)} PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 resque:scheduler > /dev/null}
         end
       end
     end


### PR DESCRIPTION
If any code writes to STDOUT during `rake resque:restart` then capistrano hangs.

I've redirected the output of this command to `/dev/null`, which allows the cap
task to complete.

Yes, this will swallow errors. I'm new to working with `capistrano` in this way
and open to suggestions on how to handle that in a more friendly way.

In the meantime, this branch might help some people have cleaner deploys.

/cc @pengwynn
