### PR TITLE
Add :resque_redirection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ It may help to redirect the output to a file.  Here's how you can direct all out
 stderr) to `log/resque.log`:
 
 ```ruby
-set :resque_redirection, ">> log/resque.log 2>> log/resque.log"
+set :resque_log_file, "log/resque.log"
 ```
 
 ### Limitations

--- a/lib/capistrano-resque/tasks/capistrano-resque.rake
+++ b/lib/capistrano-resque/tasks/capistrano-resque.rake
@@ -47,7 +47,8 @@ namespace :resque do
           number_of_workers.times do
             pid = "./tmp/pids/resque_work_#{worker_id}.pid"
             within current_path do
-              execute :rake, %{RAILS_ENV=#{fetch(:rails_env)} QUEUE="#{queue}" PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{fetch(:interval)} #{"environment" if fetch(:resque_environment_task)} resque:work #{fetch(:resque_redirection)}}
+              redirection = ">> #{fetch(:resque_log_file)} 2>> #{fetch(:resque_log_file)}" if fetch(:resque_log_file)
+              execute :rake, %{RAILS_ENV=#{fetch(:rails_env)} QUEUE="#{queue}" PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{fetch(:interval)} #{"environment" if fetch(:resque_environment_task)} resque:work #{redirection}}
             end
             worker_id += 1
           end


### PR DESCRIPTION
This worked for me to solve the `Errno::EIO: Input/output error - <STDERR>` error I was getting whenever my resque job tried to output to `$stderr`.
