### PR TITLE
Add readme instructions for enabling pid sharing between deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ role :resque_scheduler, "app_domain"
 
 set :workers, { "my_queue_name" => 2 }
 
+set :linked_dirs, %w(tmp/pids)
+
 # Uncomment this line if your workers need access to the Rails environment:
 # set :resque_environment_task, true
 ```


### PR DESCRIPTION
Fixes a bug where previous workers were not being stopped because the "current" revision had a new version of the pids directory, and therefore did not contain the old pids for capistrano to kill by putting tmp/pids in the "shared" directory.
