### PR TITLE
Allow dynamic schedule for resque scheduler

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -12,6 +12,7 @@ module CapistranoResque
         _cset(:resque_environment_task, false)
         _cset(:resque_log_file, "/dev/null")
         _cset(:resque_pid_path) { File.join(shared_path, 'tmp', 'pids') }
+        _cset(:resque_dynamic_schedule, false)
 
         def rails_env
           fetch(:resque_rails_env, fetch(:rails_env, "production"))
@@ -75,6 +76,7 @@ module CapistranoResque
         def start_scheduler(pid)
           "cd #{current_path} && RAILS_ENV=#{rails_env} \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 \
+           #{"DYNAMIC_SCHEDULE=yes" if fetch(:resque_dynamic_schedule)} \
            #{fetch(:bundle_cmd, "bundle")} exec rake \
            #{"environment" if fetch(:resque_environment_task)} \
            resque:scheduler #{output_redirection}"

--- a/lib/capistrano-resque/tasks/capistrano-resque.rake
+++ b/lib/capistrano-resque/tasks/capistrano-resque.rake
@@ -6,6 +6,7 @@ namespace :load do
     set :resque_environment_task, false
     set :resque_log_file, "/dev/null"
     set :resque_pid_path, -> { File.join(shared_path, 'tmp', 'pids') }
+    set :resque_dynamic_schedule, false
   end
 end
 
@@ -128,7 +129,7 @@ namespace :resque do
         create_pid_path
         pid = "#{fetch(:resque_pid_path)}/scheduler.pid"
         within current_path do
-          execute :rake, %{RAILS_ENV=#{rails_env} PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 #{"environment" if fetch(:resque_environment_task)} resque:scheduler #{output_redirection}}
+          execute :rake, %{RAILS_ENV=#{rails_env} PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 #{"DYNAMIC_SCHEDULE=yes" if fetch(:resque_dynamic_schedule)} #{"environment" if fetch(:resque_environment_task)} resque:scheduler #{output_redirection}}
         end
       end
     end
@@ -149,4 +150,3 @@ namespace :resque do
     end
   end
 end
-

--- a/lib/capistrano-resque/tasks/capistrano-resque.rake
+++ b/lib/capistrano-resque/tasks/capistrano-resque.rake
@@ -144,6 +144,7 @@ namespace :resque do
       end
     end
 
+    desc "Restart resque scheduler"
     task :restart do
       invoke "resque:scheduler:stop"
       invoke "resque:scheduler:start"


### PR DESCRIPTION
This changes allow turning on resque dynamic schedule. Also, it fixes `resque:scheduler:start` not showing up when doing `cap -T`