### PR TITLE
Allow adding of arbitrary environment variables to start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ The above will start five workers in total:
  * one listening on the `search_index, cache_warming` queue
  * three listening on the `mailing` queue
 
+If you need to pass arbitrary data (like other non-standard environment variables) to the "start" command, you can specify:
+
+```ruby
+set :extra_env, "SEARCH_SERVER=172.18.0.52"
+```
+
+This can be useful for customizing Resque tasks in complex server environments.
+
 ### Multiple Servers/Roles
 
 You can also start up workers on multiple servers/roles:

--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -7,6 +7,7 @@ module CapistranoResque
       capistrano_config.load do
 
         _cset(:workers, {"*" => 1})
+        _cset(:extra_env, "")
         _cset(:resque_kill_signal, "QUIT")
         _cset(:interval, "5")
         _cset(:resque_environment_task, false)
@@ -45,7 +46,7 @@ module CapistranoResque
 
         def start_command(queue, pid)
           "cd #{current_path} && RAILS_ENV=#{rails_env} QUEUE=\"#{queue}\" \
-           PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{interval} \
+           PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{interval} #{extra_env}\
            #{fetch(:bundle_cmd, "bundle")} exec rake \
            #{"environment" if fetch(:resque_environment_task)} \
            resque:work #{output_redirection}"

--- a/lib/capistrano-resque/tasks/capistrano-resque.rake
+++ b/lib/capistrano-resque/tasks/capistrano-resque.rake
@@ -1,6 +1,7 @@
 namespace :load do
   task :defaults do
     set :workers, {"*" => 1}
+    set :extra_env, ""
     set :resque_kill_signal, "QUIT"
     set :interval, "5"
     set :resque_environment_task, false
@@ -68,7 +69,7 @@ namespace :resque do
           number_of_workers.times do
             pid = "#{fetch(:resque_pid_path)}/resque_work_#{worker_id}.pid"
             within current_path do
-              execute :rake, %{RAILS_ENV=#{rails_env} QUEUE="#{queue}" PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{fetch(:interval)} #{"environment" if fetch(:resque_environment_task)} resque:work #{output_redirection}}
+              execute :rake, %{RAILS_ENV=#{rails_env} #{fetch(:extra_env)} QUEUE="#{queue}" PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 INTERVAL=#{fetch(:interval)} #{"environment" if fetch(:resque_environment_task)} resque:work #{output_redirection}}
             end
             worker_id += 1
           end


### PR DESCRIPTION
I had a need to pass some arbitrary info into Resque via environment vars.  Added a quick and easy way to do this...adds a lot of flexibility in my opinion.