### PR TITLE
Add nohup to avoid SIGHUP.

### DIFF
--- a/lib/capistrano-resque/capistrano_integration.rb
+++ b/lib/capistrano-resque/capistrano_integration.rb
@@ -73,7 +73,7 @@ module CapistranoResque
         end
 
         def start_scheduler(pid)
-          "cd #{current_path} && RAILS_ENV=#{rails_env} \
+          "cd #{current_path} && nohup RAILS_ENV=#{rails_env} \
            PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 \
            #{fetch(:bundle_cmd, "bundle")} exec rake \
            #{"environment" if fetch(:resque_environment_task)} \

--- a/lib/capistrano-resque/tasks/capistrano-resque.rake
+++ b/lib/capistrano-resque/tasks/capistrano-resque.rake
@@ -128,7 +128,7 @@ namespace :resque do
         create_pid_path
         pid = "#{fetch(:resque_pid_path)}/scheduler.pid"
         within current_path do
-          execute :rake, %{RAILS_ENV=#{rails_env} PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 #{"environment" if fetch(:resque_environment_task)} resque:scheduler #{output_redirection}}
+          execute :nohup, %{#{SSHKit.config.command_map[:rake]} RAILS_ENV=#{rails_env} PIDFILE=#{pid} BACKGROUND=yes VERBOSE=1 MUTE=1 #{"environment" if fetch(:resque_environment_task)} resque:scheduler #{output_redirection}}
         end
       end
     end


### PR DESCRIPTION
`resque:scheduler:start` sometimes fails to start the scheduler. Receiving SIGHUP is reported in `log/resque.log`. I think it happens because the background process goes backend and receive SIGHUP when capistrano logout from the connection. We should use nohup.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/sshingler/capistrano-resque/96)
<!-- Reviewable:end -->
